### PR TITLE
Support bundle with extension

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -68,7 +68,31 @@ var sendResponse = function(jDoc, myRes, ip, bid, callback, gzip) {
 		
 		var responseHeaders = {'Content-Type': responseType, 'vary': 'Accept-Encoding', 'max-age': jDoc.secleft, 'cache-control': 'public, max-age='+jDoc.secleft+', no-transform', "Expires": jDoc.expires, "Last-Modified": jDoc.lastModified};
 		
-		doc = JSON.stringify(jDoc);
+		var ext = bid.match(/\.[\w]+$/);
+		if (ext && (ext = ext[0])) {
+			// When the bid has an extension, we only return the first api.
+			var first = _.find(jDoc, function(api, key) {
+				return api && api.cname;
+			});
+			doc = first.result;
+			
+			switch (ext) {
+				case ".kml":
+				case ".xml":
+					// When expecting response is KML or XML, we set the correct Content-Type
+					// and wrap it with quotes if it's a JSONP request.
+					responseHeaders['Content-Type'] = 'text/xml';
+					callback && (doc = "'"+ doc+"'");
+					break;
+				case ".json":
+					// Content-Type for JSON is already set above.
+					doc = JSON.stringify(doc);
+				default:
+					break;
+			}
+		} else {
+			doc = JSON.stringify(jDoc);
+		}
 		
 		if (callback) {
 			doc = callback + '(' + doc + ');';	


### PR DESCRIPTION
Bundle with extension in its name will has API response served
directly instead of the standard JSON response.

Currently, the supported extensions are `.kml`, `.xml`, `.json`.

Note that when using this type of bundle, only the first key in
the bundle will be served.

For example, by exporting `sample.kml` instead of just `sample`,
the first API's response will be returned when performing request
to `/sample.kml`.
