### PR TITLE
Made some changes on testing locks.

### DIFF
--- a/lib/bundleManager.js
+++ b/lib/bundleManager.js
@@ -59,6 +59,7 @@ var BundleManager = function() {
 					_.each(tempBundle, function(part, key) {
 						winston.info("Bundle \""+key+"\": loaded from \"" + file + "\"");
 						bundles[key] = part;
+						bundles[key].locked = false;
 					});
 				} catch(err) {
 					winston.error("Error parsing bundle \""+file+"\": "+err);

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -55,8 +55,9 @@ var sendResponse = function(jDoc, myRes, ip, bid, callback, gzip) {
 		jDoc.secleft = -1;
 	}
 	
-	if (Number(jDoc.secleft) < 0 ) {
-
+	if (Number(jDoc.secleft) < 0 && !GLOBAL.bundles[bid].locked) {
+		// Prevent other requests for this bundle from refreshing cache for time being
+		GLOBAL.bundles[bid].locked = true;
 		// The bundle has expired. Force a refresh
 		exports.fulfill( myRes, ip, bid, callback, gzip, true );
 		
@@ -195,8 +196,13 @@ exports.fulfill = function ( myRes, ip, bid, callback, gzip, override ) {
 		queriesInThisBundle--;
 	}
 
+	// locked is not an API request
+	if(_.has(bundle, 'locked')) {
+		queriesInThisBundle--;
+	}
+
 	// If override was not passed
-	if( _.isUndefined( override ) || bundle.locked) {
+	if( _.isUndefined( override )) {
 		
 		// Retrieve bundle response from Redis
 		client.get('bid'+bid, function ( err, doc ) {	
@@ -217,10 +223,6 @@ exports.fulfill = function ( myRes, ip, bid, callback, gzip, override ) {
 		
 		// ### Override was passed so we are forcing a refresh on the bundle
 		var manager = new neuron.JobManager();
-		
-		bundle.locked = true;
-		console.log('lock');
-		
 		
 		manager.addJob('fulfillPart', {
 			work: function(api, bid, key, override, cachedPart) {
@@ -282,6 +284,7 @@ exports.fulfill = function ( myRes, ip, bid, callback, gzip, override ) {
 							});
 						} else {
 							winston.error('auth type ' + api.auth.type + ' not recognized');
+							//Could potentially perma lock here if all APIs have bad types
 						}
 					} else {
 						// Authentication is not needed
@@ -419,10 +422,7 @@ exports.fulfill = function ( myRes, ip, bid, callback, gzip, override ) {
 	
 				// Save cached bundle in Redis
 				client.set('bid'+bid, JSON.stringify(tout));
-				
-				console.log('unlock');
-				bundle.locked = false;
-				
+							
 				// Determine the seconds left before expiry
 				if ( 'expires' in tout && _.isDate(tout.expires) ) {
 					tout.secleft = tout.expires.getSecondsBetween( now ) * -1;
@@ -459,6 +459,8 @@ exports.fulfill = function ( myRes, ip, bid, callback, gzip, override ) {
 					// Send the results
 					sendResponse(doc, myRes, ip, bid, callback, gzip);
 				}
+				// Open the lock at the end of the chain
+				GLOBAL.bundles[bid].locked = false;
 			}
 		});
 		


### PR DESCRIPTION
Ran some tests against the scenario of
hanging up I'm able to recreate.
With the lock in place, the hang up does not
happen any longer.

Will only allow one request per bundle to trigger
a refresh, other requests for that bundle will pull
the cache.  Multiple different bundles can trigger
their refreshes at the same time.
