### PR TITLE
Provide per-bundle oauth2 auth configuration

### DIFF
--- a/lib/oauth2.js
+++ b/lib/oauth2.js
@@ -33,7 +33,8 @@ manager.addJob('getCode', {
 		
 		winston.info('Run job oauth2:getCode');
 		
-		var oaData = GLOBAL.config.authentication[api.auth.provider];
+		var oaData = api.auth.provider;
+		_.isObject(oaData) || (oaData = GLOBAL.config.authentication[oaData]);
 
 		var oa = new oauth2(oaData.client_id,
 			oaData.client_secret,
@@ -67,70 +68,72 @@ manager.addJob('getAccessToken', {
 	
 	work: function(api, bid, key, cb, grant_type) {
 		winston.info('Run job oauth2:getAccessToken(' + grant_type + ')');
-		var oaData = GLOBAL.config.authentication[api.auth.provider],
-			self = this;
+
+		var oaData = api.auth.provider;
+		_.isObject(oaData) || (oaData = GLOBAL.config.authentication[oaData]);
+
 		var oa = new oauth2(oaData.client_id,
 			oaData.client_secret,
 			oaData.baseSite,
 			oaData.authorizePath,
 			oaData.accessTokenPath),
-            self = this;
+      self = this;
         
-        winston.debug('api = ' + JSON.stringify(api));    
-        winston.info('oaData = ' + JSON.stringify(oaData));
-        //oa.setAccessTokenName(api.credentials.access_token);
+      winston.debug('api = ' + JSON.stringify(api));    
+      winston.info('oaData = ' + JSON.stringify(oaData));
+      //oa.setAccessTokenName(api.credentials.access_token);
+      
+      var params = {
+      	"grant_type": grant_type
+      };
+      
+      var thisCode = api.credentials.code;
         
-        var params = {
-        	"grant_type": grant_type
-        }
-        
-        var thisCode = api.credentials.code;
-        
-        if (grant_type !== 'refresh_token') {
-	        params.redirect_uri = GLOBAL.config.url + '/oauth2';
+      if (grant_type !== 'refresh_token') {
+	      params.redirect_uri = GLOBAL.config.url + '/oauth2';
 	    } else {
 	    	thisCode = api.credentials.refresh_token;
-        }
+      }
         
-        winston.info('thisCode = ' + thisCode);
-        winston.info('params  = ' + JSON.stringify(params));
-        
-        oa.getOAuthAccessToken(thisCode, params, function(error, access_token, refresh_token, results) {
-	    	winston.info('Run callback for oauth2:getOAuthAccessToken');
-	    	if(error) {
-		        winston.error('Error oauth2:getOAuthAccessToken('+bid+key+'): '+JSON.stringify(error));
-		        var tout = {
-	  				expires: new Date(),
-	  				err: error,
-	  				cname: key
-	  			};
-	  			manager.enqueue('finishAuth', tout, cb);
-		        self.finsihed = true;
-	    	} else { 
-	        	winston.debug('access_token = '+access_token);
-	        	
-	        	api.credentials.type = 'oauth2';
-	        	api.credentials.provider = api.auth.provider;
-	        	api.credentials.access_token = access_token;
-	        	
-	        	winston.debug('typeof refresh_token = '+typeof refresh_token);
-	        	if (typeof refresh_token !== 'undefined') {
-	        		winston.debug('first refresh token = '+refresh_token);
-	        		api.credentials.refresh_token = refresh_token;
-	        	}
-	        	
-	        	api.credentials.expires = new Date().add({seconds: (results.expires_in - 300)});
-	        	
-	        	winston.debug(JSON.stringify(api.credentials));
+      winston.info('thisCode = ' + thisCode);
+      winston.info('params  = ' + JSON.stringify(params));
+      
+      oa.getOAuthAccessToken(thisCode || '', params, function(error, access_token, refresh_token, results) {
+    	winston.info('Run callback for oauth2:getOAuthAccessToken');
+    	if(error) {
+	        winston.error('Error oauth2:getOAuthAccessToken('+bid+key+'): '+JSON.stringify(error));
+	        var tout = {
+  				expires: new Date(),
+  				err: error,
+  				cname: key
+  			};
+  			manager.enqueue('finishAuth', tout, cb);
+	      self.finsihed = true;
+    	} else { 
+        	winston.debug('access_token = '+access_token);
+        	
+        	api.credentials.type = 'oauth2';
+        	api.credentials.provider = api.auth.provider;
+        	api.credentials.access_token = access_token;
+        	
+        	winston.debug('typeof refresh_token = '+typeof refresh_token);
+        	if (typeof refresh_token !== 'undefined') {
+        		winston.debug('first refresh token = '+refresh_token);
+        		api.credentials.refresh_token = refresh_token;
+        	}
+        	
+        	api.credentials.expires = new Date().add({seconds: (results.expires_in - 300)});
+        	
+        	winston.debug(JSON.stringify(api.credentials));
 
-	        	client.set(bid+key+'oauth2', JSON.stringify(api.credentials));
-	  			winston.debug(bid+key+'oauth2 saved');
-	  			manager.enqueue('finishAuth', true, cb, { "access_token": api.credentials.access_token });
-	  			self.finished = true;
-	  		}
-	   });
+        	client.set(bid+key+'oauth2', JSON.stringify(api.credentials));
+  			winston.debug(bid+key+'oauth2 saved');
+  			manager.enqueue('finishAuth', true, cb, { "access_token": api.credentials.access_token });
+  			self.finished = true;
+  		}
+   });
 	}
-})
+});
 
 exports.authorize = function( api, bid, key, cb ) {
 	


### PR DESCRIPTION
Instead of setting authentication configuration per service in the
`config.json`, SPAS can now take an object specified in bundle's
`auth.provider` besides string name.

For oauth2, the configuration object's keys are:
* `baseSite`
* `authorizePath`
* `accessTokenPath`
* `client_id`
* `client_secret`