### PR TITLE
Fix manager refreshing bundle

### DIFF
--- a/lib/bundleManager.js
+++ b/lib/bundleManager.js
@@ -51,8 +51,8 @@ var BundleManager = function() {
 	
 		_.each(files, function(file, idx) {
 			
-			// Make sure we ignore non-js files, dotfiles, packae.json and config.json
-			if (file.indexOf('.js') !== -1 && file.indexOf('package.json') === -1 && file.indexOf('config.json') === -1 && (file[0] !== '.' || (targetFile && targetFile.indexOf(file) != -1 ))) {
+			// Make sure we ignore non-js files, package.json and config.json
+			if (file.indexOf('.js') !== -1 && file.indexOf('package.json') === -1 && file.indexOf('config.json') === -1) {
 				// if any part fo the bundle is not valid js an error will be thrown and we ignore the rest of the file
 				try {
 					var tempBundle =  require(bundlesFolder + "/" + file);
@@ -109,7 +109,7 @@ var BundleManager = function() {
 				winston.event('Bundle file changed: ' + file);
 				
 				// To bust node's module caching we rename the file before calling updateBundle
-				var tempFile = '.'+uuid.v4();
+				var tempFile = file+'.'+uuid.v4();
 				fs.renameSync(file, tempFile);
 				self.refreshBundles(tempFile, function() {
 					// Now we can change the bundle name back to its original name


### PR DESCRIPTION
Newer version of `fs.readdirSync` [does not return `.` or `..`](http://nodejs-es.github.io/api/fs.html#fs_es_fs_readdirsync_path) and thus excluding the changed bundle from its list. This commit simply makes the temporary file readable by `fs.readdirSync` so that bundle manager can reload it correctly.

Now that we don't have `.` file when reading the bundle folder, I removed the last condition, but there may be a reason for it. Let me know if that is the case.