### PR TITLE
Fix wrong date calculations

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -375,7 +375,7 @@ exports.fulfill = function ( myRes, ip, bid, callback, gzip, override ) {
 			  			}
 
 			  			// Build the stored response
-			  			api.expires = ( now ).addSeconds( api.cacheduration );
+			  			api.expires = ( new Date() ).addSeconds( api.cacheduration );
 			  			bundle[key] = api;
 			  			//client.set('bundle'+bid, JSON.stringify(bundle));
 			  			var tout = {


### PR DESCRIPTION
`Date.prototype.addSeconds` from `date-utils` modifies the Date object,
even though it returns the new Date as well. In our case, `now` was
modified on every `startRequest` call. This caused wrong calculations
on `lastModified` and `secLeft`.

This change uses a new Date object to calculate for `api.expires`.